### PR TITLE
Increase contrast and font size to get 100 in Accessibility score on …

### DIFF
--- a/src/utils/global.css
+++ b/src/utils/global.css
@@ -1,12 +1,13 @@
 body {
-  --textColorLink: #00AA58;
-  --textColorDate: #888888;
+  --textColorLink: #008846;
+  --textColorDate: #757575;
 }
 
 .gatsby-highlight {
   margin-bottom: 1.75rem;
 }
 
-.gatsby-resp-image-figcaption {
-  font-size: 80%;
+.gatsby-resp-image-figcaption,
+small {
+  font-size: 85%;
 }


### PR DESCRIPTION
This change increases the font size for the post date and figcaption, as well as increases the contrast of green and grey text.

See https://lighthouse-dot-webdotdevsite.appspot.com//lh/html?url=https%3A%2F%2Fperf.reviews%2Fblog%2Festimar-impacto-performance%2F for a report of the current version

<img width="574" alt="Screen Shot 2020-05-22 at 5 56 17 PM" src="https://user-images.githubusercontent.com/416456/82686101-8eca5780-9c55-11ea-8ec6-547c196c3c03.png">

After:

<img width="103" alt="Screen Shot 2020-05-22 at 6 04 17 PM" src="https://user-images.githubusercontent.com/416456/82686803-b1a93b80-9c56-11ea-9677-4861fdbe83d3.png">

