### PR TITLE
fix: correct HTML/React attributes in MDX files and accordion component

### DIFF
--- a/src/components/ui/accordion.tsx
+++ b/src/components/ui/accordion.tsx
@@ -8,7 +8,8 @@ export interface AccordionProps extends React.HTMLAttributes<HTMLDivElement> {
 }
 
 export const Accordion = React.forwardRef<HTMLDivElement, AccordionProps>(
-  ({ className, children, ...props }, ref) => {
+  ({ className, children, type, collapsible, ...props }, ref) => {
+    // type and collapsible are consumed here and not passed to DOM
     return (
       <div ref={ref} className={cn("space-y-2", className)} {...props}>
         {children}
@@ -66,7 +67,8 @@ export interface AccordionContentProps extends React.HTMLAttributes<HTMLDivEleme
 }
 
 export const AccordionContent = React.forwardRef<HTMLDivElement, AccordionContentProps>(
-  ({ className, children, ...props }, ref) => {
+  ({ className, children, forceMount, ...props }, ref) => {
+    // forceMount is consumed here and not passed to DOM
     return (
       <div ref={ref} className={cn("pb-4 pt-0", className)} {...props}>
         {children}

--- a/src/posts/archived/en/estimar-impacto-performance.mdx
+++ b/src/posts/archived/en/estimar-impacto-performance.mdx
@@ -58,20 +58,22 @@ Another easy way to spot performance issues and make a business case is to look 
 Take this example:
 
 <table style={{margin:"0 auto 1rem"}}>
-    <tr>
-        <td></td>
-        <th scope="col" style={{fontWeight: "bold",textAlign:"right",padding:"0.5em 1em"}}>Mobile</th>
-        <th scope="col" style={{fontWeight: "bold",textAlign:"right",padding:"0.5em 1em"}}>Desktop</th>
-    </tr>
-    <tr>
-        <th style={{fontWeight:"bold",textAlign:"left",padding:"0.5em 1em"}} scope="row">Conversion rate</th>
-        <td style={{textAlign:"right",padding:"0.5em 1em"}}>1.79%</td>
-        <td style={{textAlign:"right",padding:"0.5em 1em"}}>4.44%</td>
-    </tr>
-    <tr>
-        <th style={{fontWeight:"bold",textAlign:"left",padding:"0.5em 1em"}} scope="row">Rel mCvR</th>
-        <td style={{fontWeight:"bold",textAlign:"right",padding:"0.5em 1em"}} colspan="2">1.79% / 4.44% = 40%</td>
-    </tr>
+    <tbody>
+        <tr>
+            <td></td>
+            <th scope="col" style={{fontWeight: "bold",textAlign:"right",padding:"0.5em 1em"}}>Mobile</th>
+            <th scope="col" style={{fontWeight: "bold",textAlign:"right",padding:"0.5em 1em"}}>Desktop</th>
+        </tr>
+        <tr>
+            <th style={{fontWeight:"bold",textAlign:"left",padding:"0.5em 1em"}} scope="row">Conversion rate</th>
+            <td style={{textAlign:"right",padding:"0.5em 1em"}}>1.79%</td>
+            <td style={{textAlign:"right",padding:"0.5em 1em"}}>4.44%</td>
+        </tr>
+        <tr>
+            <th style={{fontWeight:"bold",textAlign:"left",padding:"0.5em 1em"}} scope="row">Rel mCvR</th>
+            <td style={{fontWeight:"bold",textAlign:"right",padding:"0.5em 1em"}} colSpan={2}>1.79% / 4.44% = 40%</td>
+        </tr>
+    </tbody>
 </table>
 
 In this case, the Rel mCvR is 40%.

--- a/src/posts/archived/en/image-optimization.mdx
+++ b/src/posts/archived/en/image-optimization.mdx
@@ -146,7 +146,7 @@ It can be used both as CLI _(Command Line Interface)_ with [imagemin-cli](https:
 
 It is not a good idea to do recompress an image. In this video you can see an example of what happens when doing it:
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/w7vXJbLhTyI" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/w7vXJbLhTyI" frameBorder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowFullScreen></iframe>
 
 The format with the best results is **FLIF**<sup>(12)</sup>, but it is a format that is not supported by current browsers, so **MozJPEG** could be a viable option. But as I said, I prefer to keep the original image, in PNG if possible, to preserve all the information and generate from it, the compressed image and/or change of format.
 

--- a/src/posts/archived/en/nico-bistolfi-piio.mdx
+++ b/src/posts/archived/en/nico-bistolfi-piio.mdx
@@ -13,7 +13,7 @@ featuredImage: /images/blog/thumbs/piio.jpg
 
 We talked to [Nico Bistolfi](https://www.linkedin.com/in/nicolasbistolfi/) about the philosophy behind Piio, what makes it special, and why it is necessary to automate web performance related tasks. The interview is in Spanish, and the [video is available on Youtube](https://youtu.be/SLzhWFU52WQ). You can also listen to [the audio on MP3](/audio/entrevista-piio.mp3).
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/SLzhWFU52WQ" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in -picture "allowfullscreen> </iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/SLzhWFU52WQ" frameBorder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in -picture "allowFullScreen> </iframe>
 
 ## Transcript of the interview
 

--- a/src/posts/archived/en/video-en-la-web.mdx
+++ b/src/posts/archived/en/video-en-la-web.mdx
@@ -81,7 +81,7 @@ Surprisingly, we get a video of a very acceptable quality with a size of only **
 When implementing these formats, and to support all browsers, we will add multiple sources to a video tag:
 
 ```html
-<video autoplay loop muted playsinline>
+<video autoPlay loop muted playsInline>
   <source src="video.webm" type="video/webm">
   <source src="video.mp4" type="video/mp4">
 </video>

--- a/src/posts/archived/en/web-performance-google-io-2019.mdx
+++ b/src/posts/archived/en/web-performance-google-io-2019.mdx
@@ -195,7 +195,7 @@ _Presented in [From Low Friction to Zero Friction with Web Packaging and Portals
 
 This API lets us load the destination page in an element similar to an iframe, and control the transition between the current page and the destination page.
 
-<video controls autoplay loop muted style={{maxWidth: "100%", height: "auto"}}>
+<video controls autoPlay loop muted style={{maxWidth: "100%", height: "auto"}}>
   <source src="./thumbs/portals_vp9.webm" type="video/webm; codecs=vp8" />
   <source src="./thumbs/portals_h264.mp4" type="video/mp4; codecs=h264" />
 </video>

--- a/src/posts/archived/es/estimar-impacto-performance.mdx
+++ b/src/posts/archived/es/estimar-impacto-performance.mdx
@@ -56,45 +56,47 @@ Otra forma fácil de detectar problemas de rendimiento y hacer un caso de negoci
 Mira este ejemplo:
 
 <table style={{ margin: "0 auto 1rem" }}>
-  <tr>
-    <td></td>
-    <th
-      scope="col"
-      style={{ fontWeight: "bold", textAlign: "right", padding: "0.5em 1em" }}
-    >
-      Móvil
-    </th>
-    <th
-      scope="col"
-      style={{ fontWeight: "bold", textAlign: "right", padding: "0.5em 1em" }}
-    >
-      Escritorio
-    </th>
-  </tr>
-  <tr>
-    <th
-      style={{ fontWeight: "bold", textAlign: "left", padding: "0.5em 1em" }}
-      scope="row"
-    >
-      Tasa de conversión
-    </th>
-    <td style={{ textAlign: "right", padding: "0.5em 1em" }}>1.79%</td>
-    <td style={{ textAlign: "right", padding: "0.5em 1em" }}>4.44%</td>
-  </tr>
-  <tr>
-    <th
-      style={{ fontWeight: "bold", textAlign: "left", padding: "0.5em 1em" }}
-      scope="row"
-    >
-      Rel mCvR
-    </th>
-    <td
-      style={{ fontWeight: "bold", textAlign: "right", padding: "0.5em 1em" }}
-      colspan="2"
-    >
-      1.79% / 4.44% = 40%
-    </td>
-  </tr>
+  <tbody>
+    <tr>
+      <td></td>
+      <th
+        scope="col"
+        style={{ fontWeight: "bold", textAlign: "right", padding: "0.5em 1em" }}
+      >
+        Móvil
+      </th>
+      <th
+        scope="col"
+        style={{ fontWeight: "bold", textAlign: "right", padding: "0.5em 1em" }}
+      >
+        Escritorio
+      </th>
+    </tr>
+    <tr>
+      <th
+        style={{ fontWeight: "bold", textAlign: "left", padding: "0.5em 1em" }}
+        scope="row"
+      >
+        Tasa de conversión
+      </th>
+      <td style={{ textAlign: "right", padding: "0.5em 1em" }}>1.79%</td>
+      <td style={{ textAlign: "right", padding: "0.5em 1em" }}>4.44%</td>
+    </tr>
+    <tr>
+      <th
+        style={{ fontWeight: "bold", textAlign: "left", padding: "0.5em 1em" }}
+        scope="row"
+      >
+        Rel mCvR
+      </th>
+      <td
+        style={{ fontWeight: "bold", textAlign: "right", padding: "0.5em 1em" }}
+        colSpan={2}
+      >
+        1.79% / 4.44% = 40%
+      </td>
+    </tr>
+  </tbody>
 </table>
 
 En este caso, el Rel mCvR es del 40%.

--- a/src/posts/archived/es/image-optimization.mdx
+++ b/src/posts/archived/es/image-optimization.mdx
@@ -146,7 +146,7 @@ Se puede utilizar tanto como CLI _(Command Line Interface)_ con [imagemin-cli](h
 
 No es buena idea hacer eso, en este vídeo podréis ver un ejemplo de lo que pasa al re-comprimir la misma imagen:
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/w7vXJbLhTyI" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/w7vXJbLhTyI" frameBorder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowFullScreen></iframe>
 
 El formato con mejores resultados es **FLIF**<sup>(12)</sup>, pero es un formato que no está soportado por los navegadores actuales, así que **MozJPEG** sí que podría ser una opción viable. Pero como he comentado, a mí me gusta más conservar la imagen original, en PNG a ser posible, para conservar toda la información y generar a partir de esta, la imagen comprimida y/o cambio de formato.
 

--- a/src/posts/archived/es/nico-bistolfi-piio.mdx
+++ b/src/posts/archived/es/nico-bistolfi-piio.mdx
@@ -13,7 +13,7 @@ featuredImage: /images/blog/thumbs/piio.jpg
 
 Hablamos con [Nico Bistolfi](https://www.linkedin.com/in/nicolasbistolfi/) sobre la filosofía detrás de Piio, qué lo hace especial, y por qué es necesario automatizar las tareas relacionadas con web performance. Tenéis disponible [el vídeo en Youtube](https://youtu.be/SLzhWFU52WQ) y [el audio en MP3](/audio/entrevista-piio.mp3).
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/SLzhWFU52WQ" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/SLzhWFU52WQ" frameBorder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowFullScreen></iframe>
 
 ## Transcripción de la entrevista
 

--- a/src/posts/archived/es/video-en-la-web.mdx
+++ b/src/posts/archived/es/video-en-la-web.mdx
@@ -80,7 +80,7 @@ Sorprendentemente obtenemos un vídeo de una calidad muy aceptable con un tamañ
 A la hora de implementar estos formatos, y para dar soporte a todos los navegadores, añadiremos múltiples sources a una etiqueta vídeo:
 
 ```html
-<video autoplay loop muted playsinline>
+<video autoPlay loop muted playsInline>
   <source src="video.webm" type="video/webm">
   <source src="video.mp4" type="video/mp4">
 </video>

--- a/src/posts/archived/es/web-performance-google-io-2019.mdx
+++ b/src/posts/archived/es/web-performance-google-io-2019.mdx
@@ -196,7 +196,7 @@ _Presentado en [From Low Friction to Zero Friction with Web Packaging and Portal
 
 Lo que nos permitirá hacer esta nueva API es cargar la página destino en un elemento similar a un iframe, y poder controlar una transición entre la página actual y la página destino.
 
-<video controls autoplay loop muted style={{maxWidth: "100%", height: "auto"}}>
+<video controls autoPlay loop muted style={{maxWidth: "100%", height: "auto"}}>
   <source src="/images/blog/thumbs/portals_vp9.webm" type="video/webm; codecs=vp8" />
   <source src="/images/blog/thumbs/portals_h264.mp4" type="video/mp4; codecs=h264" />
 </video>

--- a/src/reviews/archived/en/elcorteingles.mdx
+++ b/src/reviews/archived/en/elcorteingles.mdx
@@ -11,9 +11,9 @@ featuredImage: /images/reviews/elcorteingles/thumb.png
   width="560"
   height="315"
   src="https://www.youtube.com/embed/yyLAPxgwSGM"
-  frameborder="0"
+  frameBorder="0"
   allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
-  allowfullscreen
+  allowFullScreen
 />
 
 ## Reports and Tools

--- a/src/reviews/archived/en/escuelait.mdx
+++ b/src/reviews/archived/en/escuelait.mdx
@@ -15,9 +15,9 @@ Here’s our analysis:
   width="560"
   height="315"
   src="https://www.youtube.com/embed/qyXs6d7wc5Y"
-  frameborder="0"
+  frameBorder="0"
   allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
-  allowfullscreen
+  allowFullScreen
 />
 
 ---

--- a/src/reviews/archived/en/mediamarkt.mdx
+++ b/src/reviews/archived/en/mediamarkt.mdx
@@ -11,9 +11,9 @@ featuredImage: /images/reviews/mediamarkt/thumb.png
   width="560"
   height="315"
   src="https://www.youtube.com/embed/xD8MbFUZPKQ"
-  frameborder="0"
+  frameBorder="0"
   allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
-  allowfullscreen
+  allowFullScreen
 />
 
 ## Reports and Tools

--- a/src/reviews/archived/en/renfe.mdx
+++ b/src/reviews/archived/en/renfe.mdx
@@ -15,9 +15,9 @@ Here is our analysis:
   width="560"
   height="315"
   src="https://www.youtube.com/embed/pi02YqNHjJs"
-  frameborder="0"
+  frameBorder="0"
   allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
-  allowfullscreen
+  allowFullScreen
 />
 
 ---

--- a/src/reviews/archived/en/smashingmagazine.mdx
+++ b/src/reviews/archived/en/smashingmagazine.mdx
@@ -11,9 +11,9 @@ featuredImage: /images/reviews/smashingmagazine/thumb.png
   width="560"
   height="315"
   src="https://www.youtube.com/embed/NalgDNrjHUg"
-  frameborder="0"
+  frameBorder="0"
   allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
-  allowfullscreen
+  allowFullScreen
 />
 
 ### References

--- a/src/reviews/archived/en/zara.mdx
+++ b/src/reviews/archived/en/zara.mdx
@@ -11,9 +11,9 @@ featuredImage: /images/reviews/zara/thumb.png
   width="560"
   height="315"
   src="https://www.youtube.com/embed/QbJAf5Oa64Y"
-  frameborder="0"
+  frameBorder="0"
   allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
-  allowfullscreen
+  allowFullScreen
 />
 
 > Thanks to [Paco Segovia](https://twitter.com/SeGo) and [Jaime Lozano](https://twitter.com/jlozanospain) for suggesting this site for the review.

--- a/src/reviews/archived/es/elcorteingles.mdx
+++ b/src/reviews/archived/es/elcorteingles.mdx
@@ -11,9 +11,9 @@ featuredImage: /images/reviews/elcorteingles/thumb.png
   width="560"
   height="315"
   src="https://www.youtube.com/embed/yyLAPxgwSGM"
-  frameborder="0"
+  frameBorder="0"
   allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
-  allowfullscreen
+  allowFullScreen
 />
 
 ## Informes y herramientas

--- a/src/reviews/archived/es/escuelait.mdx
+++ b/src/reviews/archived/es/escuelait.mdx
@@ -15,9 +15,9 @@ Aquí tienes nuestro análisis:
   width="560"
   height="315"
   src="https://www.youtube.com/embed/qyXs6d7wc5Y"
-  frameborder="0"
+  frameBorder="0"
   allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
-  allowfullscreen
+  allowFullScreen
 />
 
 ---

--- a/src/reviews/archived/es/mediamarkt.mdx
+++ b/src/reviews/archived/es/mediamarkt.mdx
@@ -11,9 +11,9 @@ featuredImage: /images/reviews/mediamarkt/thumb.png
   width="560"
   height="315"
   src="https://www.youtube.com/embed/xD8MbFUZPKQ"
-  frameborder="0"
+  frameBorder="0"
   allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
-  allowfullscreen
+  allowFullScreen
 />
 
 ## Informes y herramientas

--- a/src/reviews/archived/es/renfe.mdx
+++ b/src/reviews/archived/es/renfe.mdx
@@ -15,9 +15,9 @@ Aquí tienes nuestro análisis:
   width="560"
   height="315"
   src="https://www.youtube.com/embed/pi02YqNHjJs"
-  frameborder="0"
+  frameBorder="0"
   allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
-  allowfullscreen
+  allowFullScreen
 />
 
 ---

--- a/src/reviews/archived/es/smashingmagazine.mdx
+++ b/src/reviews/archived/es/smashingmagazine.mdx
@@ -11,9 +11,9 @@ featuredImage: /images/reviews/smashingmagazine/thumb.png
   width="560"
   height="315"
   src="https://www.youtube.com/embed/NalgDNrjHUg"
-  frameborder="0"
+  frameBorder="0"
   allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
-  allowfullscreen
+  allowFullScreen
 />
 
 ### Referencias

--- a/src/reviews/archived/es/zara.mdx
+++ b/src/reviews/archived/es/zara.mdx
@@ -11,9 +11,9 @@ featuredImage: /images/reviews/zara/thumb.png
   width="560"
   height="315"
   src="https://www.youtube.com/embed/QbJAf5Oa64Y"
-  frameborder="0"
+  frameBorder="0"
   allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
-  allowfullscreen
+  allowFullScreen
 />
 
 > Gracias a [Paco Segovia](https://twitter.com/SeGo) y [Jaime Lozano](https://twitter.com/jlozanospain) por sugerirnos este site para la review.


### PR DESCRIPTION
## Summary
- Corrects deprecated HTML attributes to React equivalents in archived MDX files
- Fixes prop handling in accordion component to prevent non-DOM props from being passed to DOM elements

## Changes
- Replace `colspan` with `colSpan` in table elements
- Replace `frameborder` with `frameBorder` in iframes  
- Replace `allowfullscreen` with `allowFullScreen` in iframes
- Add missing `<tbody>` wrappers to table elements for valid HTML structure
- Update accordion component to properly consume non-DOM props (`type`, `collapsible`, `forceMount`)

## Test plan
- [x] Verify no React warnings in console for archived content pages
- [x] Check that tables and iframes render correctly
- [x] Verify accordion component works without DOM attribute warnings